### PR TITLE
updateChecker.js fix/workaround for Ubiq Fusion

### DIFF
--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -19,9 +19,6 @@ const check = exports.check = () => {
     case 'mist':
         str = 'fusion';		// we need to search for Fusion in the release:name
         break;
-    case 'fusion':
-        str = 'fusion';
-        break;
     case 'wallet':
         str = 'wallet';
         break;
@@ -33,16 +30,9 @@ const check = exports.check = () => {
     })
     .then((res) => {
         const releases = _.filter(res.body, (release) => {
-            // as at v0.9.1 the 'release.name' does not contain the words Mist, Fusion or Wallet
-            // as a result the new version check fails. All fusion releases to date have the word
-            // 'Version' in the release.name .. so we can search for that and check will succeed.
-            // If future release names include the words 'Fusion' and 'Wallet' then the below hack
-            // can be removed. Refer to the naming returned by the ethereum/mist/releases API call
-            // eg. "name": "Ethereum Wallet and Mist 0.9.1",
             return (
                 !_.get(release, 'draft')
                 && _.get(release, 'name', '').toLowerCase().indexOf(str) >= 0
-                || _.get(release, 'name', '').indexOf('Version') >= 0	// nasty workaround for fusion
             );
         });
 

--- a/modules/updateChecker.js
+++ b/modules/updateChecker.js
@@ -17,7 +17,10 @@ const check = exports.check = () => {
 
     switch (Settings.uiMode) {  // eslint-disable-line default-case
     case 'mist':
-        str = 'mist';
+        str = 'fusion';		// we need to search for Fusion in the release:name
+        break;
+    case 'fusion':
+        str = 'fusion';
         break;
     case 'wallet':
         str = 'wallet';
@@ -30,9 +33,16 @@ const check = exports.check = () => {
     })
     .then((res) => {
         const releases = _.filter(res.body, (release) => {
+            // as at v0.9.1 the 'release.name' does not contain the words Mist, Fusion or Wallet
+            // as a result the new version check fails. All fusion releases to date have the word
+            // 'Version' in the release.name .. so we can search for that and check will succeed.
+            // If future release names include the words 'Fusion' and 'Wallet' then the below hack
+            // can be removed. Refer to the naming returned by the ethereum/mist/releases API call
+            // eg. "name": "Ethereum Wallet and Mist 0.9.1",
             return (
                 !_.get(release, 'draft')
                 && _.get(release, 'name', '').toLowerCase().indexOf(str) >= 0
+                || _.get(release, 'name', '').indexOf('Version') >= 0	// nasty workaround for fusion
             );
         });
 


### PR DESCRIPTION
#### What does it do?
Adds some workarounds to updateCheck.js so that it will detect new Fusion releases

#### Any helpful background information?
updateChecker.js looks at the json returned from api.github.com/repos/ubiq/fusion/releases 
It iterates over the {releases} looking at the {release.name} element on each release.
For Fusion we have:
`    "name": "Version 0.9.1",`
`    "name": "Version 0.8.10 (bug fix)",`
etc.

As at v0.9.1 the 'release.name' does not contain the words 'Mist', 'Fusion' or 'Wallet'.
As a result the new version check fails. All fusion releases to date have the word
'Version' in the {release.name} .. so  as a workaround we can search for that and check will succeed.

If future release names include the words 'Fusion' and 'Wallet' then the workaround 
can be removed. Refer to the names returned by the ethereum/mist/releases API call
eg. 
`"name": "Ethereum Wallet and Mist 0.9.1",`
`"name": "Ethereum Wallet and Mist 0.9.0 \"It's happening\"",`
`"name": "Ethereum Wallet and Mist v0.8.10",`
etc

